### PR TITLE
Squash China and the US to one number

### DIFF
--- a/resources/views/locations/_location-name.blade.php
+++ b/resources/views/locations/_location-name.blade.php
@@ -1,1 +1,1 @@
-{{ $location['country'] }} <span class="text-gray-600">({{ implode(', ', array_filter([$location['province'], $location['country_code']], fn ($item) => !empty($item))) }})</span>
+{{ $location['country'] }} <span class="text-gray-600">({{ $location['country_code'] }})</span>


### PR DESCRIPTION
### Changed

- China and the US are now shown as one number on the homepage.

---

**To-do**

- [ ] The detail pages for China and the US should be updated to display a global graph, plus the blocks per province so you can click through.